### PR TITLE
Development

### DIFF
--- a/Launchpad 2.au3
+++ b/Launchpad 2.au3
@@ -13,8 +13,8 @@
 #include <GUIConstantsEx.au3>
 #include <Misc.au3>
 #include <MsgBoxConstants.au3>
-#include <SendMessage.au3>
 #include <WindowsConstants.au3>
+#include <SendMessage.au3>
 
 ;~ ; CUSTOM SCRIPTS
 #include <scripts\PopUpMenu.au3>
@@ -39,7 +39,7 @@ Global $EvosusWindow = "Evosus";
 ; Global $EvosusWindow = "TEST MODE!"
 Global $ShipworksWindow = "ShipWorks"
 Global $ChromeWindow = "Chrome"
-Global $NotepadWindow = WinGetHandle("Notepad++")
+Global $NotepadWindow = WinGetHandle("Notepad")
 Global $pmtMemo[1] ; Payment memo placeholder until we have some data.
 Global $regexAMZ = "P01-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}|P01-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}"
 Global $regexCRD = "\b\d{11}"
@@ -223,8 +223,7 @@ WEnd
 Func testFunc()
 	ClipPut("The quick brown fox jumps over the lazy dog.")
 	WinActivate($NotepadWindow)
-	_SendMessage($NotepadWindow, $WM_PASTE)
-	ClipPut(_SendMessage($NotepadWindow, $WM_PASTE))
+	_SendMessage($NotepadWindow, $WM_COMMAND, 770, 0)
 EndFunc ; testFunc()
 ; END TEST FUNCTION SECTION
 

--- a/Launchpad 2.au3
+++ b/Launchpad 2.au3
@@ -25,7 +25,7 @@ Opt("WinTitleMatchMode", 2); Match any substring in the window title.
 
 ; GUI SECTION
 Global $AppTitle = "Launchpad 2"
-Global $AppVersion = "v. 2.1.1a"
+Global $AppVersion = "v. 2.1.1"
 Global $AppWidth = 400
 Global $AppHeight = 68
 ;~ Global $MainWindow = GUICreate($AppTitle, $AppWidth, $AppHeight, @DesktopWidth-$AppWidth-5, @DesktopHeight-$AppHeight-32)
@@ -184,21 +184,21 @@ While 1
 	GUICtrlSetOnEvent($Btn_Memo, "inputMemo")
 
 	GUICtrlSetOnEvent($Btn_AzAddress, "btnAzAddress") ; AMAZON
-	GUICtrlSetOnEvent($Btn_AzCst, "btnAzCst")
+	GUICtrlSetOnEvent($Btn_AzCst, "newCstImport")
 	GUICtrlSetOnEvent($Btn_AzPmt, "azPmt")
 
 	GUICtrlSetOnEvent($Btn_ebLookCst, "ebLook"); EBAY
-	GUICtrlSetOnEvent($Btn_EbCst, "ebCst")
+	GUICtrlSetOnEvent($Btn_EbCst, "newCstImport")
 	GUICtrlSetOnEvent($Btn_EbPmt, "ebPmt")
 
 	GUICtrlSetOnEvent($Btn_CtLookup, "ctLookup") ; CART
-	GUICtrlSetOnEvent($Btn_CtCst, "ctCst")
+	GUICtrlSetOnEvent($Btn_CtCst, "newCstImport")
 	GUICtrlSetOnEvent($Btn_CtCard, "ctPmt") ; One function for multiple payment methods.
 	GUICtrlSetOnEvent($Btn_CtPayPal, "ctPmt")
 	GUICtrlSetOnEvent($Btn_CtAmazon, "ctPmt")
 
 	GUICtrlSetOnEvent($Btn_WmAddress, "wmAddress") ; WAL-MART
-	GUICtrlSetOnEvent($Btn_WmCst, "wmCst")
+	GUICtrlSetOnEvent($Btn_WmCst, "newCstImport")
 	GUICtrlSetOnEvent($Btn_WmPmt, "wmPmt")
 
 	; POPUP MENU EVENTS SECTION
@@ -250,6 +250,7 @@ Func evosusStockLookup() ; Secret Stock Lookup Function! :)
 EndFunc ; evosusStockLookup()
 
 Func evosusDeposit() ; Secret Evosus Deposit Function! :)
+	ControlCommand($EvosusWindow, "", "[CLASS:ThunderRT6ComboBox; INSTANCE:25]", "SelectString", "Parts")
 	WinActivate($EvosusWindow, "")
 	ControlClick($EvosusWindow, "Make Deposit", 89) ; Click "Make Deposit"
 EndFunc ; evosusPayment()
@@ -270,10 +271,6 @@ Func canadaCheck()
 		Global $CAZip = StringRegExp($orderArray[16], $regexCA, 1) ; Return an array of matches. No offset.
 		ControlFocus("New Customer", "", 69) ; Focus the dropdown control
 		ControlCommand("New Customer", "", "[ID:69]", "SelectString", "Canada") ; Select "Canada"
-		ControlClick("New Customer", "", 71); Click on the Postal code field to shock the State dropdown into submission when State lookup happens.
-		ClipPut($orderArray[17]) ; Load phone number
-		ControlFocus("New Customer", "", "[CLASS:MSMaskWndClass; INSTANCE:2]") ; Focus phone number field
-		ControlSend("New Customer", "","[CLASS:MSMaskWndClass; INSTANCE:2]", "{CTRLDOWN}v{CTRLUP}") ; Paste phone number
 	EndIf
 EndFunc ; canadaCheck()
 
@@ -306,49 +303,6 @@ Func btnAddress()
 			orderInfo() ; Show user info box right away.
 	EndIf
 EndFunc ; $Btn_AzAddress
-
-Func btnAzCst()
-	If UBound($orderArray) > 15 Then ; Check if zip code exists.
-	WinActivate($EvosusWindow)
-	WinActivate("New Customer")
-	newCstWinCheck() ; Check for New Customer window
-
-	; Fill in marketing information as part of customer entry.
-	ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]") ; Focus "What?"
-	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]", "SelectString", "Accessories") ; Select "Accessories"
-	ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]") ; Focus "Contact Type"
-	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]", "SelectString", "Internet/Email") ; Select "Internet/Email"
-	ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]") ; Focus "Gender"
-	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]", "SelectString", "Male") ; Select "Male"
-
-	canadaCheck()
-
-	ClipPut($orderArray[8]); Load First Name
-	ControlSend("New Customer", "", 68, "{CTRLDOWN}v{CTRLUP}") ; Paste First Name
-	ClipPut($orderArray[9]) ; Load Last Name
-	ControlSend("New Customer", "", 67, "{CTRLDOWN}v{CTRLUP}") ; Paste Last Name
-	ClipPut($orderArray[10]) ; Load Company Name
-	ControlSend("New Customer", "", 63, "{CTRLDOWN}v{CTRLUP}") ; Paste Company Name
-	ClipPut($orderArray[11]) ; Load Address Line 1
-	ControlSend("New Customer", "", 74, "{CTRLDOWN}v{CTRLUP}") ; Paste Address Line 1
-	ClipPut($orderArray[12]); Load Address Line 2
-	ControlSend("New Customer", "", 73, "{CTRLDOWN}v{CTRLUP}") ; Paste Address Line 2
-	ClipPut($orderArray[14]) ; Load City
-	ControlSend("New Customer", "", 72, "{CTRLDOWN}v{CTRLUP}") ; Paste City
-		; TODO: Add a preferences screen.
-		; TODO: Add a checkbox: "Bypass Lookup [F6]" If that's checked, do the following:
-		;~ ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:23]") ; Focus State dropdown
-		;~ ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:23]", "SelectString", $orderArray[15]); Select the state from customer's profile.
-		; Else, do this:
-	ClipPut($orderArray[16]) ; Load Postal Code
-	ControlSend("New Customer", "", 71, "{CTRLDOWN}v{CTRLUP}{F6}") ; Paste Postal Code. Look up City and State.
-	;~ ControlSend("New Customer", "", 71, "{CTRLDOWN}v{CTRLUP}") ; Paste Postal Code. Look up City and State.
-	Else
-		MsgBox(64, "Missing Order Info.", "Double check order details with the info button.") ; Info box.
-		orderInfo() ; Show user info box right away.
-	EndIf
-EndFunc ; btnAzCst()
-
 
 Func azPmt()
 	WinActivate($EvosusWindow)
@@ -444,47 +398,6 @@ Func ebLook()
 	btnAddress() ; Look up address in Evosus.
 EndFunc ; ebLook()
 
-Func ebCst()
-	If UBound($orderArray) > 16 Then ; Check if phone number exists
-		WinActivate($EvosusWindow)
-		WinActivate("New Customer")
-		newCstWinCheck() ; Check for New Customer window
-
-		; Fill in marketing information as part of customer entry.
-		ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]") ; Focus "What?"
-		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]", "SelectString", "Accessories") ; Select "Accessories"
-		ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]") ; Focus "Contact Type"
-		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]", "SelectString", "Internet/Email") ; Select "Internet/Email"
-		ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]") ; Focus "Gender"
-		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]", "SelectString", "Male") ; Select "Male"
-
-		ClipPut($orderArray[8]); Load First Name
-		ControlSend("New Customer", "", 68, "{CTRLDOWN}v{CTRLUP}") ; Paste First Name
-		ClipPut($orderArray[9]) ; Load Last Name
-		ControlSend("New Customer", "", 67, "{CTRLDOWN}v{CTRLUP}") ; Paste Last Name
-		ClipPut($orderArray[10]) ; Load Company Name
-		ControlSend("New Customer", "", 63, "{CTRLDOWN}v{CTRLUP}") ; Paste Company Name
-		ClipPut($orderArray[11]) ; Load Address Line 1
-		ControlSend("New Customer", "", 74, "{CTRLDOWN}v{CTRLUP}") ; Paste Address Line 1
-		ClipPut($orderArray[12]); Load Address Line 2
-		ControlSend("New Customer", "", 73, "{CTRLDOWN}v{CTRLUP}") ; Paste Address Line 2
-
-		canadaCheck()
-
-		; TODO: Add a checkbox: "Bypass Lookup [F6]" If that's checked, do the following:
-		ClipPut($orderArray[14]) ; Load City
-		ControlSend("New Customer", "", 72, "{CTRLDOWN}v{CTRLUP}") ; Paste City
-		ClipPut($orderArray[17]) ; Load phone number
-		ControlFocus("New Customer", "", "[CLASS:MSMaskWndClass; INSTANCE:2]") ; Focus phone field.
-		ControlSend("New Customer", "","[CLASS:MSMaskWndClass; INSTANCE:2]", "{CTRLDOWN}v{CTRLUP}") ; Paste phone number
-		ClipPut($orderArray[16]) ; Load Postal Code
-		ControlSend("New Customer", "", 71, "{CTRLDOWN}v{CTRLUP}{F6}") ; Paste Postal Code. Look up City and State.
-		Else
-			MsgBox(64, "Missing Order Info.", "Double check order details with the info button.") ; Info box.
-			orderInfo() ; Show user info box right away.
-	EndIf
-EndFunc ; ebLook()
-
 Func ebPmt()
 	WinActivate($EvosusWindow)
 	ClipPut($orderArray[4]) ; Load eBay order number
@@ -497,53 +410,6 @@ Func ebPmt()
 	ControlCommand($EvosusWindow, "", "[ID:10]", "SelectString", "Credit Card - EBAY") ; Select Ebay payment method.
 	bypassAndInvoice()
 EndFunc ; ebPmt()
-
-
-Func ctCst()
-	If UBound($orderArray) > 15 Then ; Check if zip code exists.
-		WinActivate($EvosusWindow)
-		WinActivate("New Customer")
-		newCstWinCheck()
-
-		; Fill in marketing information as part of customer entry.
-		ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]") ; Focus "What?"
-		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]", "SelectString", "Accessories") ; Select "Accessories"
-		ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]") ; Focus "Contact Type"
-		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]", "SelectString", "Internet/Email") ; Select "Internet/Email"
-		ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]") ; Focus "Gender"
-		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]", "SelectString", "Male") ; Select "Male"
-
-		ClipPut($orderArray[8]); Load First Name
-		ControlSend("New Customer", "", 68, "{CTRLDOWN}v{CTRLUP}") ; Paste First Name
-		ClipPut($orderArray[9]) ; Load Last Name
-		ControlSend("New Customer", "", 67, "{CTRLDOWN}v{CTRLUP}") ; Paste Last Name
-		ClipPut($orderArray[10]) ; Load Company Name
-		ControlSend("New Customer", "", 63, "{CTRLDOWN}v{CTRLUP}") ; Paste Company Name
-		ClipPut($orderArray[11]) ; Load Address Line 1
-		ControlSend("New Customer", "", 74, "{CTRLDOWN}v{CTRLUP}") ; Paste Address Line 1
-		ClipPut($orderArray[12]); Load Address Line 2
-		ControlSend("New Customer", "", 73, "{CTRLDOWN}v{CTRLUP}") ; Paste Address Line 2
-		ClipPut($orderArray[21]) ; Load email address
-		ControlSend("New Customer", "", "[CLASS:ThunderRT6TextBox; INSTANCE:27]", "{CTRLDOWN}v{CTRLUP}") ; Paste email address
-		ClipPut($orderArray[17]) ; Load phone number
-		ControlFocus("New Customer", "", "[CLASS:MSMaskWndClass; INSTANCE:2]") ; Focus phone field to make sure it stays.
-		ControlSend("New Customer", "","[CLASS:MSMaskWndClass; INSTANCE:2]", "{CTRLDOWN}v{CTRLUP}") ; Paste phone number
-
-		canadaCheck()
-		
-			; TODO: Add a preferences screen.
-			; TODO: Add a checkbox: "Bypass Lookup [F6]" If that's checked, do the following:
-			ClipPut($orderArray[14]) ; Load City
-			ControlSend("New Customer", "", 72, "{CTRLDOWN}v{CTRLUP}") ; Paste City
-			; Else, do this:
-		ClipPut($orderArray[16]) ; Load Postal Code
-		ControlSend("New Customer", "", 71, "{CTRLDOWN}v{CTRLUP}{F6}") ; Paste Postal Code. Look up City and State.
-
-		Else
-			MsgBox(64, "Missing Order Info.", "Zip code line nonexistent. Double check order details with the info button.") ; Info box.
-			orderInfo() ; Show user info box right away.
-	EndIf
-EndFunc ; ctCst()
 
 Func ctPmt()
 	WinActivate($EvosusWindow)
@@ -583,12 +449,6 @@ Func wmAddress()
 	btnAddress()
 	wmWebsite()
 EndFunc ; wmAddress()
-
-Func wmCst()
-	GUICtrlSetData($statusBar, $orderArray[2]); Show WalMart order number in status bar.
-	ebCst()
-	wmWebsite()
-EndFunc ; wmCst()
 
 Func wmPmt()
 	WinActivate($EvosusWindow)
@@ -983,13 +843,21 @@ Func newCstImport()
 
 	; Fill in marketing information as part of customer entry.
 	ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]") ; Focus "What?"
-	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]", "SelectString", "Accessories") ; Select "Accessories"
+	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:18]", "SelectString", "Parts") ; Select "Parts"
 	ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]") ; Focus "Contact Type"
 	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:2]", "SelectString", "Internet/Email") ; Select "Internet/Email"
 	ControlFocus("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]") ; Focus "Gender"
 	ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:6]", "SelectString", "Male") ; Select "Male"
 
 	canadaCheck()
+
+	; Enter Phone if order is not Amazon.com
+	If ($orderArray[1] <> "Amazon") Then
+		ClipPut($orderArray[17]) ; Load phone number
+		ControlClick("New Customer", "", 71); Click on the Postal code field to shock the State dropdown into submission when State lookup happens.
+		ControlFocus("New Customer", "", "[CLASS:MSMaskWndClass; INSTANCE:2]") ; Focus phone number field
+		ControlSend("New Customer", "","[CLASS:MSMaskWndClass; INSTANCE:2]", "{CTRLDOWN}v{CTRLUP}") ; Paste phone number
+	EndIf
 
 	ClipPut($orderArray[8]); Load First Name
 	ControlSend("New Customer", "", 68, "{CTRLDOWN}v{CTRLUP}") ; Paste First Name
@@ -1009,10 +877,24 @@ Func newCstImport()
 		ControlCommand("New Customer", "", "[CLASS:ThunderRT6ComboBox; INSTANCE:23]", "SelectString", $orderArray[15]); Select the state from customer's profile.
 		; Else, do this:
 	;~ ControlSend("New Customer", "", 71, "{CTRLDOWN}v{CTRLUP}{F6}") ; Paste Postal Code. Look up City and State.
+
+	; email Check
+	If ($orderArray[1] = "Earth Sense") Then
+		ClipPut($orderArray[21]) ; Load email address
+		ControlSend("New Customer", "", "[CLASS:ThunderRT6TextBox; INSTANCE:27]", "{CTRLDOWN}v{CTRLUP}") ; Paste email address
+	EndIf
+
 	ClipPut($orderArray[16]) ; Load Postal Code
 	ControlSend("New Customer", "", 71, "{CTRLDOWN}v{CTRLUP}") ; Paste Postal Code. Look up City and State.
+
+	If ($orderArray[1] = "WalMart") Then
+		wmWebsite()
+	EndIf
+
 	Else
 		MsgBox(64, "Missing Order Info.", "Double check order details with the info button.") ; Info box.
 		orderInfo() ; Show user info box right away.
 	EndIf
 EndFunc ; newCstImport()
+
+;~ 1034 lines

--- a/Launchpad 2.au3
+++ b/Launchpad 2.au3
@@ -13,6 +13,7 @@
 #include <GUIConstantsEx.au3>
 #include <Misc.au3>
 #include <MsgBoxConstants.au3>
+#include <SendMessage.au3>
 #include <WindowsConstants.au3>
 
 ;~ ; CUSTOM SCRIPTS
@@ -38,6 +39,7 @@ Global $EvosusWindow = "Evosus";
 ; Global $EvosusWindow = "TEST MODE!"
 Global $ShipworksWindow = "ShipWorks"
 Global $ChromeWindow = "Chrome"
+Global $NotepadWindow = WinGetHandle("Notepad++")
 Global $pmtMemo[1] ; Payment memo placeholder until we have some data.
 Global $regexAMZ = "P01-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}|P01-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}"
 Global $regexCRD = "\b\d{11}"
@@ -219,7 +221,10 @@ WEnd
 
 ; TEST FUNCTION SECTION
 Func testFunc()
-
+	ClipPut("The quick brown fox jumps over the lazy dog.")
+	WinActivate($NotepadWindow)
+	_SendMessage($NotepadWindow, $WM_PASTE)
+	ClipPut(_SendMessage($NotepadWindow, $WM_PASTE))
 EndFunc ; testFunc()
 ; END TEST FUNCTION SECTION
 

--- a/Launchpad 2.au3
+++ b/Launchpad 2.au3
@@ -630,7 +630,7 @@ Func showAmazonButtons()
 	; Re-set quick text labels. Keep them from disappearing.
 	SetTextMenuLabels ()
 
-	HotKeySet("^!a", "btnAddress") ; Set hotkeys for Amazon buttons.
+	HotKeySet("^!a", "btnAzAddress") ; Set hotkeys for Amazon buttons.
 	HotKeySet("^!c", "btnAzCst")
 	HotKeySet("^!p", "azPmt")
 EndFunc ; showAmazonButtons()

--- a/Launchpad 2.au3
+++ b/Launchpad 2.au3
@@ -15,6 +15,8 @@
 #include <MsgBoxConstants.au3>
 #include <WindowsConstants.au3>
 
+#include <GuiTreeView.au3>
+
 ;~ ; CUSTOM SCRIPTS
 #include <scripts\PopUpMenu.au3>
 
@@ -37,7 +39,6 @@ Global $orderArray
 Global $EvosusWindow = "Evosus";
 ; Global $EvosusWindow = "TEST MODE!"
 Global $ShipworksWindow = "ShipWorks"
-Global $ChromeWindow = "Chrome"
 Global $NotepadWindow = WinGetHandle("Notepad")
 Global $pmtMemo[1] ; Payment memo placeholder until we have some data.
 Global $regexAMZ = "P01-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}|P01-[A-Za-z0-9]{7}-[A-Za-z0-9]{7}"
@@ -220,12 +221,7 @@ WEnd
 
 ; TEST FUNCTION SECTION
 Func testFunc()
-		WinActivate($EvosusWindow, 10)
-		Local $EWinCheck = WinWaitActive ($EvosusWindow, "", 5)
-		If ($EWinCheck <> 0) Then
-			ControlClick($EvosusWindow, "", "[CLASS:ThunderRT6CommandButton; INSTANCE:136]")
-			ControlCommand($EvosusWindow, "", "[CLASS:ThunderRT6CommandButton; INSTANCE:136]", "SelectString", "Add")
-		EndIf
+
 EndFunc ; testFunc()
 ; END TEST FUNCTION SECTION
 
@@ -285,27 +281,20 @@ Func wmWebsite()
 EndFunc ; wmWebsite()
 
 Func btnAzAddress()
-	WinActivate($ChromeWindow)
-	Send("{CTRLDOWN}t{CTRLUP}") ; Make new tab. Automatically focuses address bar.
-	WinWaitActive("New Tab", "", 1) ; Wait for the new tab window to appear.
-	ClipPut($AmazonSearch & $orderArray[3])
-	Send("{CTRLDOWN}v{CTRLUP}{ENTER}") ; Paste Amazon order number and GO
-
+	ShellExecute($AmazonSearch & $orderArray[3])
 	btnAddress()
 EndFunc ; btnAzAddress()
 
 Func btnAddress()
 	If UBound($orderArray) > 10 Then ; If address field exists, do stuff.
-		ClipPut($orderArray[11])
 		WinActivate($EvosusWindow)
 		WinMenuSelectItem($EvosusWindow, "", "&Go To", "Customers")
-		ControlClick($EvosusWindow, "Street Name", 49); Click on Street Name to clear Address Field
 		ControlClick($EvosusWindow, "Address", 52); Click on Address field
-		ControlFocus ($EvosusWindow, "", 63); Focus address field in the Evosus window
-		ControlSend($EvosusWindow, "", 63, "{CTRLDOWN}v{CTRLUP}{ENTER}")
-		Else
-			MsgBox(64, "Missing Order Info.", "Address line nonexistent. Review order info.") ; Info box.
-			orderInfo() ; Show user info box right away.
+		ControlSetText($EvosusWindow, "","[CLASS:ThunderRT6TextBox; INSTANCE:5]", $orderArray[11]); Set address text
+		ControlClick($EvosusWindow, "", 56); Click lookup customer.
+	Else
+		MsgBox(64, "Missing Order Info.", "Address line nonexistent. Review order info.") ; Info box.
+		orderInfo() ; Show user info box right away.
 	EndIf
 EndFunc ; $Btn_AzAddress
 
@@ -365,39 +354,18 @@ Func bypassAndInvoice()
 EndFunc ; bypassAndInvoice()
 
 Func ctLookup()
-	WinActivate($ChromeWindow) 
-	Send("{CTRLDOWN}t{CTRLUP}") ; Make new tab. Automatically focuses address bar.
-	WinWaitActive("New Tab", "", 1) ; Wait for the new tab window to appear.
-	ClipPut($cartSearch[0] & $orderArray[2] & $cartSearch[1]) ; Concatenate and load the entire Cart URL
-	Send("{CTRLDOWN}v{CTRLUP}{ENTER}") ; Paste last part of Cart search url and GO.
-
-	If WinActivate ($ChromeWindow) = 0 Then
-		MsgBox(64, "Chrome Not Open", "Google Chrome is not open. Open Google Chrome and try again.")
-	EndIf
+	ShellExecute($cartSearch[0] & $orderArray[2] & $cartSearch[1])
 	btnAddress()
 EndFunc ; ctLookup()
 
 
 Func ebLook()
-	WinActivate($ChromeWindow) 
-	Send("{CTRLDOWN}t{CTRLUP}") ; Make new tab. Automatically focuses address bar.
-	WinWaitActive("New Tab", "", 1) ; Wait for the new tab window to appear.
-	ClipPut($ebaySearch & $orderArray[4]) ; Load eBay search url
-	Send("{CTRLDOWN}v{CTRLUP}{ENTER}") ; Paste eBay order number into address bar and GO
-
+	ShellExecute($ebaySearch & $orderArray[4])
 	btnAddress() ; Look up address in Evosus.
 EndFunc ; ebLook()
 
 Func wmAddress()
-	WinActivate($ChromeWindow)
-	Send("{CTRLDOWN}t{CTRLUP}") ; Make new tab. Automatically focuses address bar.
-	WinWaitActive("New Tab", "", 1) ; Wait for the new tab window to appear.
-	ClipPut($wmSearch) ; Load WalMart Seller Central
-	Send("{CTRLDOWN}v{CTRLUP}{ENTER}") ; Paste WalMart Seller Central and GO
-
-	If WinActivate ($ChromeWindow) = 0 Then
-		MsgBox(64, "Chrome Not Open", "Google Chrome is not open. Open Google Chrome and try again.")
-	EndIf
+	ShellExecute($wmSearch)
 	btnAddress()
 	wmWebsite()
 EndFunc ; wmAddress()
@@ -710,43 +678,43 @@ EndFunc
 Func Oos()
     InitialsCheck()
     ClipPut($OosText & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 EndFunc
 
 Func Fraud()
     InitialsCheck()
     ClipPut($FraudText & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 EndFunc
 
 Func Backordered()
     InitialsCheck()
     ClipPut($BoText & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 EndFunc
 
 Func BadAddress()
     InitialsCheck()
     ClipPut($BadAddressText[0] & $orderArray[11] & $BadAddressText[1] & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 EndFunc
 
 Func BadAddressContacted()
     InitialsCheck()
     ClipPut($BadAddressContactedText & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 EndFunc
 
 Func EmailTracking()
     InitialsCheck()
     ClipPut($EmailTrackingText & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 Endfunc
 
 Func EmailShippingChange()
     InitialsCheck()
     ClipPut($EmailshippingChangeText & $SigDate)
-    _ToolTip("Text copied!", 1500)
+    _ToolTip("Text copied!", 2000)
 EndFunc
 
 Func InitialsCheck()
@@ -798,13 +766,11 @@ Func newCstImport()
 		ControlClick("New Customer", "", 71); Click on the Postal code field to shock the State dropdown into submission when State lookup happens.
 		ControlFocus("New Customer", "", "[CLASS:MSMaskWndClass; INSTANCE:2]") ; Focus phone number field
 		ControlSend("New Customer", "","[CLASS:MSMaskWndClass; INSTANCE:2]", "{CTRLDOWN}v{CTRLUP}") ; Paste phone number
-	EndIf
 
-	;~ If ($orderArray[1] <> "Amazon") Then
-	;~ 	ControlClick($NCWindow, "", 71); Click on the Postal code field to shock the State dropdown into submission when State lookup happens.
-	;~ 	ControlSend($NCWindow, "", "[CLASS:MSMaskWndClass; INSTANCE:2]", "v") ; Send right arrow to keep number from disappearing later.
-	;~ 	ControlCommand($NCWindow, "", "[CLASS:MSMaskWndClass; INSTANCE:2]", "EditPaste", $orderArray[17]); Paste phone number
-	;~ EndIf
+		;~ ControlClick("New Customer", "", 71); Click on the Postal code field to shock the State dropdown into submission when State lookup happens.
+		;~ ControlSetText("New Customer", "", "[CLASS:MSMaskWndClass; INSTANCE:2]", $orderArray[17]); Paste phone number
+
+	EndIf
 
 	ControlCommand($NCWindow, "", "[CLASS:ThunderRT6TextBox; INSTANCE:22]", "EditPaste", $orderArray[8]) ;First Name
 	ControlCommand($NCWindow, "", "[CLASS:ThunderRT6TextBox; INSTANCE:21]", "EditPaste", $orderArray[9]) ;Last Name

--- a/Launchpad 2.au3
+++ b/Launchpad 2.au3
@@ -223,7 +223,8 @@ Func testFunc()
 		WinActivate($EvosusWindow, 10)
 		Local $EWinCheck = WinWaitActive ($EvosusWindow, "", 5)
 		If ($EWinCheck <> 0) Then
-			WinMenuSelectItem($EvosusWindow, "", "&Go To", "Customers")
+			ControlClick($EvosusWindow, "", "[CLASS:ThunderRT6CommandButton; INSTANCE:136]")
+			ControlCommand($EvosusWindow, "", "[CLASS:ThunderRT6CommandButton; INSTANCE:136]", "SelectString", "Add")
 		EndIf
 EndFunc ; testFunc()
 ; END TEST FUNCTION SECTION


### PR DESCRIPTION

## What's Changed
* Fixed an issue where the Order Import and Memo input screens would be covered up by the main Launchpad window in #9 .
* Amazon address lookup hotfix. Now it looks up the customer **and** the order if you use the hotkey in #13.
* Amazon.ca orders now select the correct type of credit card in the Payment screen.
* Fixed #14. Forces new customer interest to "Parts" instead of "Accessories." Changes the order's Customer Interest to "Parts" regardless of its previous selection.
* Streamlined how the Customer tab is forced into focus on address lookup. 
* #15. Fixed an issue where the Payment screen automation would sometimes not uncheck the "Print on Save" box depending on how you got to the Payment screen.
* Consolidated the Payment functions down to one with lots of options. (easier editing)
* Improved and sped up how an order is looked up by eliminating CTRL+V in the process.
* Improved and sped up how a customer is looked up in Evosus by eliminating CTRL+V in the process.
* Improved and sped up the process by which customer information is copied into Evosus.
* Increased the amount of time quick text tooltip is displayed.


**Full Changelog**: https://github.com/bschultz1990/Launchpad/compare/release...v2.1.1